### PR TITLE
Enable student UI and fix base URL

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,12 +1,6 @@
 RewriteEngine On
 
-# Si l'URL est vide (racine), redirige vers public/index.html
-RewriteCond %{REQUEST_URI} ^/?$
-RewriteRule ^$ public/index.html [L]
-
-# Laisser passer les fichiers/dossiers existants
+# Redirige toutes les requêtes vers le contrôleur principal
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-
-# Sinon, rediriger vers public (utile pour CSS, JS, images, etc.)
-RewriteRule ^(.*)$ public/$1 [L]
+RewriteRule ^ index.php [QSA,L]

--- a/app/config/config1.php
+++ b/app/config/config1.php
@@ -32,7 +32,7 @@ $app->path(__DIR__ . $ds . '..' . $ds . '..');
 $app->path(__DIR__ . $ds . '..' . $ds . 'controllers');
 
 // This is where you can set some flight config variables. 
-$app->set('flight.base_url','/ETU003329/20250204'); // if this is in a subdirectory, you'll need to change this
+$app->set('flight.base_url', '/examen_web_s4'); // chemin de base de l'application
 $app->set('flight.case_sensitive', false); // if you want case sensitive routes, set this to true
 $app->set('flight.log_errors', true); // if you want to log errors, set this to true
 $app->set('flight.handle_errors', false); // if you want flight to handle errors, set this to true, otherwise Tracy will handle them

--- a/app/controllers/WelcomeController.php
+++ b/app/controllers/WelcomeController.php
@@ -11,10 +11,11 @@ class WelcomeController {
 
 	}
 
-    //pour tester le template
+    // Affiche l'interface de gestion d'étudiants
     public function homeTemplate() {
         $data = ['page' => "home"];
-        Flight::render('welcome', $data);
+        // On charge la vue principale qui communique avec le web service
+        Flight::render('index', $data);
     }
 
 }


### PR DESCRIPTION
## Summary
- update `.htaccess` to redirect requests to `index.php`
- update `base_url` for the XAMPP path
- show the student management view by default

## Testing
- `php -l app/controllers/WelcomeController.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ba47a4f3c83318b3bb66d3939f9b6