### PR TITLE
Add Etudiant model and service

### DIFF
--- a/ws/index.php
+++ b/ws/index.php
@@ -1,41 +1,14 @@
 <?php
 require 'vendor/autoload.php';
 require 'db.php';
+require_once __DIR__ . '/services/EtudiantService.php';
 
-Flight::route('GET /etudiants', function () {
-    $db = getDB();
-    $stmt = $db->query("SELECT * FROM etudiant");
-    Flight::json($stmt->fetchAll(PDO::FETCH_ASSOC));
-});
+$service = new EtudiantService();
 
-Flight::route('GET /etudiants/@id', function ($id) {
-    $db = getDB();
-    $stmt = $db->prepare("SELECT * FROM etudiant WHERE id = ?");
-    $stmt->execute([$id]);
-    Flight::json($stmt->fetch(PDO::FETCH_ASSOC));
-});
-
-Flight::route('POST /etudiants', function () {
-    $data = Flight::request()->data;
-    $db = getDB();
-    $stmt = $db->prepare("INSERT INTO etudiant (nom, prenom, email, age) VALUES (?, ?, ?, ?)");
-    $stmt->execute([$data->nom, $data->prenom, $data->email, $data->age]);
-    Flight::json(['message' => 'Étudiant ajouté', 'id' => $db->lastInsertId()]);
-});
-
-Flight::route('PUT /etudiants/@id', function ($id) {
-    $data = Flight::request()->data;
-    $db = getDB();
-    $stmt = $db->prepare("UPDATE etudiant SET nom = ?, prenom = ?, email = ?, age = ? WHERE id = ?");
-    $stmt->execute([$data->nom, $data->prenom, $data->email, $data->age, $id]);
-    Flight::json(['message' => 'Étudiant modifié']);
-});
-
-Flight::route('DELETE /etudiants/@id', function ($id) {
-    $db = getDB();
-    $stmt = $db->prepare("DELETE FROM etudiant WHERE id = ?");
-    $stmt->execute([$id]);
-    Flight::json(['message' => 'Étudiant supprimé']);
-});
+Flight::route('GET /etudiants', [$service, 'getAll']);
+Flight::route('GET /etudiants/@id', [$service, 'get']);
+Flight::route('POST /etudiants', [$service, 'create']);
+Flight::route('PUT /etudiants/@id', [$service, 'update']);
+Flight::route('DELETE /etudiants/@id', [$service, 'delete']);
 
 Flight::start();

--- a/ws/models/EtudiantModel.php
+++ b/ws/models/EtudiantModel.php
@@ -1,0 +1,42 @@
+<?php
+class EtudiantModel {
+    private PDO $db;
+    public function __construct(PDO $db) {
+        $this->db = $db;
+    }
+    public function all(): array {
+        $stmt = $this->db->query("SELECT * FROM etudiant");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+    public function get(int $id): array|false {
+        $stmt = $this->db->prepare("SELECT * FROM etudiant WHERE id = ?");
+        $stmt->execute([$id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+    public function create(array $data): int {
+        $stmt = $this->db->prepare("INSERT INTO etudiant (nom, prenom, email, age) VALUES (?, ?, ?, ?)");
+        $stmt->execute([
+            $data['nom'],
+            $data['prenom'],
+            $data['email'],
+            $data['age']
+        ]);
+        return (int)$this->db->lastInsertId();
+    }
+    public function update(int $id, array $data): int {
+        $stmt = $this->db->prepare("UPDATE etudiant SET nom = ?, prenom = ?, email = ?, age = ? WHERE id = ?");
+        $stmt->execute([
+            $data['nom'],
+            $data['prenom'],
+            $data['email'],
+            $data['age'],
+            $id
+        ]);
+        return $stmt->rowCount();
+    }
+    public function delete(int $id): int {
+        $stmt = $this->db->prepare("DELETE FROM etudiant WHERE id = ?");
+        $stmt->execute([$id]);
+        return $stmt->rowCount();
+    }
+}

--- a/ws/services/EtudiantService.php
+++ b/ws/services/EtudiantService.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../models/EtudiantModel.php';
+
+class EtudiantService {
+    private EtudiantModel $model;
+
+    public function __construct() {
+        $this->model = new EtudiantModel(getDB());
+    }
+
+    public function getAll() {
+        Flight::json($this->model->all());
+    }
+
+    public function get($id) {
+        Flight::json($this->model->get($id));
+    }
+
+    public function create() {
+        $data = Flight::request()->data->getData();
+        $id = $this->model->create($data);
+        Flight::json(['message' => 'Étudiant ajouté', 'id' => $id]);
+    }
+
+    public function update($id) {
+        $data = Flight::request()->data->getData();
+        $this->model->update($id, $data);
+        Flight::json(['message' => 'Étudiant modifié']);
+    }
+
+    public function delete($id) {
+        $this->model->delete($id);
+        Flight::json(['message' => 'Étudiant supprimé']);
+    }
+}


### PR DESCRIPTION
## Summary
- add EtudiantModel for CRUD operations on `etudiant` table
- create EtudiantService to expose model actions
- update `ws/index.php` to use the new service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686baa4181988331bc660481c66f5dd1